### PR TITLE
Major Screen Fixes + Minor Player Fixes

### DIFF
--- a/Source/Grimthole.cs
+++ b/Source/Grimthole.cs
@@ -22,27 +22,24 @@ namespace Grimthole.MacOS.Source
             Content.RootDirectory = "Content";
         }
 
-		protected override void BeginRun()
-		{
-			// TODO: Code for splashscreen with M1 Logo.
-			base.BeginRun();
-		}
-
-		protected override void Initialize()
+        protected override void Initialize()
         {
-			graphics.PreferredBackBufferHeight = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height;
-			graphics.PreferredBackBufferWidth = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width;
-			graphics.ApplyChanges();
+            graphics.PreferredBackBufferHeight = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height - 100;
+            graphics.PreferredBackBufferWidth = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width - 100;
+		    graphics.ApplyChanges();
+
+			ScreenManager.Instance.Initialise();
 
             base.Initialize();
         }
+    
         
         protected override void LoadContent()
         {
             // Create a new SpriteBatch, which can be used to draw textures.
             spriteBatch = new SpriteBatch(GraphicsDevice);
 
-			ScreenManager.Instance.LoadContent(Content);
+            ScreenManager.Instance.LoadContent(Content);
         }
 
         protected override void Update(GameTime gameTime)
@@ -50,16 +47,17 @@ namespace Grimthole.MacOS.Source
             if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape))
                 Exit();
 
-
 			ScreenManager.Instance.Update(gameTime);
+
             base.Update(gameTime);
         }
 
         protected override void Draw(GameTime gameTime)
         {
             graphics.GraphicsDevice.Clear(Color.Black);
-            
-			ScreenManager.Instance.Draw(spriteBatch);
+
+            ScreenManager.Instance.Draw(spriteBatch);
+
             base.Draw(gameTime);
         }
     }

--- a/Source/Player.cs
+++ b/Source/Player.cs
@@ -1,0 +1,116 @@
+﻿using System;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Input;
+
+using Grimthole.MacOS.Source.Utils;
+
+namespace Grimthole.MacOS.Source
+{
+    public class Player : SpriteManager
+    {
+		public Player(Vector2 coords) : base("Sprites/Man2front", coords, 
+		    ScreenManager.Instance.TileSize, ScreenManager.Instance.TileSize)
+        {
+        }
+        
+		public override void Update(Rectangle windowDimensions, GameTime gt, ContentManager content)
+        {
+            GamePadCapabilities capabilities = GamePad.GetCapabilities(PlayerIndex.One);
+            
+			int delta = (int)(gt.ElapsedGameTime.TotalMilliseconds * 0.4);
+            
+			if (capabilities.IsConnected)
+            {
+                // Get the current state of Controller1
+                GamePadState state = GamePad.GetState(PlayerIndex.One);
+
+                if (capabilities.HasLeftXThumbStick)
+                {
+                    if (state.ThumbSticks.Left.X < -0.5f)
+                    {
+						MoveCommand.MoveLeft(this, delta);
+                        name = "Sprites/Man2left";
+                    }
+
+                    if (state.ThumbSticks.Left.X > 0.5f)
+                    {
+						MoveCommand.MoveRight(this, delta);
+                        name = "Sprites/Man2right";
+                    }
+
+                    if (state.ThumbSticks.Left.Y > 0.5f)
+                    {
+						MoveCommand.MoveDown(this, delta);
+                        name = "Sprites/Man2back";
+                    }
+
+                    if (state.ThumbSticks.Left.Y < -0.5f)
+                    {
+						MoveCommand.MoveUp(this, delta);
+                        name = "Sprites/Man2front";
+                    }
+                }
+
+            }
+            else
+            {
+                if (Keyboard.GetState().IsKeyDown(Keys.D))
+				{
+					MoveCommand.MoveRight(this, delta);
+					name = "Sprites/Man2right";
+				}
+
+                if (Keyboard.GetState().IsKeyDown(Keys.A))
+				{
+					MoveCommand.MoveLeft(this, delta);
+					name = "Sprites/Man2left";
+				}
+
+				if (Keyboard.GetState().IsKeyDown(Keys.W))
+				{
+					MoveCommand.MoveUp(this, delta);
+					name = "Sprites/Man2back";
+				}
+
+                if (Keyboard.GetState().IsKeyDown(Keys.S))
+				{
+					MoveCommand.MoveDown(this, delta);
+					name = "Sprites/Man2front";
+				}
+            }
+
+			CheckEdgeCases(windowDimensions);
+			LoadContent(content);
+        }
+
+        /// <summary>
+        /// Checks the player has not moved off the edges.
+        /// </summary>
+		/// <param name="windowDimensions">The dimensions of the game window.</param>
+		void CheckEdgeCases(Rectangle windowDimensions)
+        {
+			if (SpriteDimensions.Left < 0)
+			{
+				MoveCommand.MoveRight(this, Math.Abs(0 - SpriteDimensions.Left));
+			}
+		             
+			if (SpriteDimensions.Top < 0)
+			{
+				MoveCommand.MoveDown(this, Math.Abs(0 - SpriteDimensions.Top));
+			}
+
+			if (SpriteDimensions.Right > windowDimensions.Width)
+			{
+				MoveCommand.MoveLeft(this, Math.Abs(windowDimensions.Width - SpriteDimensions.Right));
+			}
+            
+			if (SpriteDimensions.Bottom > windowDimensions.Height)
+			{
+				MoveCommand.MoveUp(this, Math.Abs(windowDimensions.Height - SpriteDimensions.Bottom));
+			}
+
+        }
+    }
+}

--- a/Source/Screens/SplashScreen.cs
+++ b/Source/Screens/SplashScreen.cs
@@ -1,0 +1,64 @@
+﻿using System;
+
+using Grimthole.MacOS.Source.Utils;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Grimthole.MacOS.Source.Screens
+{
+	public class SplashScreen : GameScreen
+    {
+		Texture2D logo;
+		Rectangle logoPosition;
+		double timer;
+
+		public override void LoadContent()
+		{         
+			base.LoadContent();
+
+            // We only want to spend 4 seconds on the splash screen.
+			timer = 4;
+
+			// The logo should appear in the centre of the screen, and slightly
+			// above 1/2 way up to make room for the Text.
+            
+			// The logo dimensions are the (screen height / 3 * screen height / 3).
+			int logoSize = ScreenManager.Instance.Dimensions.Height / 3;
+            
+			Point topLeftPosition = new Point(
+				(ScreenManager.Instance.Dimensions.Width / 2) - (logoSize / 2),
+				(ScreenManager.Instance.Dimensions.Height / 2) - 4 * (logoSize / 5));
+
+			Point heightAndWidth = new Point(
+				logoSize,
+				logoSize);
+            
+            // The rectangle that the logo fills.
+			logoPosition = new Rectangle(
+				topLeftPosition,
+                heightAndWidth);
+            
+			logo = Content.Load<Texture2D>("Logos/logo");
+		}
+
+		public override void Update(GameTime gameTime)
+		{
+			if (timer > 0) 
+			{
+				timer -= gameTime.ElapsedGameTime.TotalSeconds;
+			}
+			else
+			{
+				ScreenManager.Instance.ChangeScreen(new VillageScreen());
+			}
+		}
+        
+		public override void Draw(SpriteBatch spriteBatch)
+		{
+			spriteBatch.Begin();
+			spriteBatch.Draw(logo, logoPosition, Color.White);
+			spriteBatch.End();
+		}
+	}
+}

--- a/Source/Screens/VillageScreen.cs
+++ b/Source/Screens/VillageScreen.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Grimthole.MacOS.Source.Utils;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Grimthole.MacOS.Source.Screens
+{
+    public class VillageScreen : GameScreen
+    {
+        Texture2D tile;
+        Point tileHeightAndWidth;
+		List<Point> points = new List<Point>();
+        
+        Player player;
+
+		public override void LoadContent()
+        {
+			base.LoadContent();
+            
+            player = new Player(new Vector2(200, 200));         
+            player.LoadContent(Content);         
+            
+            // The top left position of each background tile.
+			for (var i = 0; i < ScreenManager.Instance.Dimensions.Width; i += ScreenManager.Instance.TileSize)
+            {
+				for (var j = 0; j < ScreenManager.Instance.Dimensions.Height; j += ScreenManager.Instance.TileSize)
+                {
+                    points.Add(new Point(i, j));
+                }
+            }
+
+            // The height and width of the tiles.
+            tileHeightAndWidth = new Point(
+				ScreenManager.Instance.TileSize,
+				ScreenManager.Instance.TileSize
+            );         
+
+            tile = Content.Load<Texture2D>("Backgrounds/Grass-1");
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+			player.Update(ScreenManager.Instance.Dimensions, gameTime, Content);
+        }
+
+        public override void Draw(SpriteBatch spriteBatch)
+		{
+            spriteBatch.Begin();
+            foreach (Point point in points)
+            {
+                spriteBatch.Draw(tile, new Rectangle(point, tileHeightAndWidth), Color.White);
+            }         
+            spriteBatch.End();
+
+			player.Draw(spriteBatch);
+        }
+	}
+}

--- a/Source/Utils/GameScreen.cs
+++ b/Source/Utils/GameScreen.cs
@@ -1,10 +1,13 @@
-﻿using Microsoft.Xna.Framework;
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Grimthole.MacOS.Source.Utils
 {
-    public class GameScreen
+	public abstract class GameScreen
     {
 		protected ContentManager Content;
 
@@ -17,14 +20,13 @@ namespace Grimthole.MacOS.Source.Utils
 			);
 		}
 
-		public virtual void Update(GameTime gameTime)
+		public virtual void UnloadContent()
 		{
-			
+			Content.Dispose();
 		}
 
-		public virtual void Draw(SpriteBatch spriteBatch)
-		{
-			
-		}
+		public abstract void Update(GameTime gameTime);
+
+		public abstract void Draw(SpriteBatch spriteBatch);
     }
 }

--- a/Source/Utils/MoveCommand.cs
+++ b/Source/Utils/MoveCommand.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+
+namespace Grimthole.MacOS.Source.Utils
+{
+
+    /// <summary>
+	/// This class is uses the Command Software Design Pattern to take a Sprite
+	/// and move it in the desired direction by changing it's rectangle.
+    /// </summary>
+	public static class MoveCommand
+    {
+		public static void MoveUp(SpriteManager sprite, int delta)
+		{
+			sprite.SpriteDimensions = new Rectangle(
+				sprite.SpriteDimensions.X,
+				sprite.SpriteDimensions.Y - delta,
+				sprite.SpriteDimensions.Width,
+				sprite.SpriteDimensions.Height
+			);
+		}
+
+		public static void MoveDown(SpriteManager sprite, int delta)
+        {
+			sprite.SpriteDimensions = new Rectangle(
+				sprite.SpriteDimensions.X,
+				sprite.SpriteDimensions.Y + delta,
+				sprite.SpriteDimensions.Width,
+				sprite.SpriteDimensions.Height
+            );
+        }
+
+		public static void MoveLeft(SpriteManager sprite, int delta)
+        {
+			sprite.SpriteDimensions = new Rectangle(
+				sprite.SpriteDimensions.X - delta,
+				sprite.SpriteDimensions.Y,
+				sprite.SpriteDimensions.Width,
+				sprite.SpriteDimensions.Height
+            );
+        }
+
+		public static void MoveRight(SpriteManager sprite, int delta)
+        {
+			sprite.SpriteDimensions = new Rectangle(
+				sprite.SpriteDimensions.X + delta,
+				sprite.SpriteDimensions.Y,
+				sprite.SpriteDimensions.Width,
+				sprite.SpriteDimensions.Height
+            );
+        }
+    }
+}

--- a/Source/Utils/ScreenManager.cs
+++ b/Source/Utils/ScreenManager.cs
@@ -8,12 +8,16 @@ using Grimthole.MacOS.Source.Screens;
 
 namespace Grimthole.MacOS.Source.Utils
 {
-    public class ScreenManager
+	/// <summary>
+    /// This Screen Manager switches between the relevant screens in the game.
+    /// </summary>
+	public class ScreenManager
     {
 		static ScreenManager instance;
-		public Vector2 dimensions { get; private set; }
-		public ContentManager Content { get; private set; }
 
+		public readonly int TileSize = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height / 16;
+		public Rectangle Dimensions { get; private set; }
+		public ContentManager Content { get; private set; }
 		GameScreen currentScreen;
 
 		public static ScreenManager Instance 
@@ -31,25 +35,31 @@ namespace Grimthole.MacOS.Source.Utils
         ScreenManager()
         {
 			// Set to Full Screen
-			dimensions = new Vector2(
-				GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width,
-				GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height
+			Dimensions = new Rectangle(
+				0,
+                0,
+				GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width - 100,
+				GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height - 100
 			);
-
-			currentScreen = new SpashScreen();
         }
 
-		public void Initialise(GraphicsAdapter graphicsAdapter)
+		public void Initialise()
 		{
-			
+			currentScreen = new SplashScreen();
 		}
 
+        public void ChangeScreen(GameScreen gameScreen)
+        {
+            currentScreen = gameScreen;
+			currentScreen.LoadContent();
+        }
+        
 		public void LoadContent(ContentManager content)
 		{
 			Content = new ContentManager(content.ServiceProvider, "Content");
 			currentScreen.LoadContent();
 		}
-
+        
 		public void Update(GameTime gameTime)
 		{
 			currentScreen.Update(gameTime);

--- a/Source/Utils/SpriteManager.cs
+++ b/Source/Utils/SpriteManager.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Content;
+
+namespace Grimthole.MacOS.Source.Utils
+{ 
+    public abstract class SpriteManager
+    {
+        protected String name;
+        protected Color[] spriteData;
+        protected Texture2D sprite;
+		public Rectangle SpriteDimensions { get; set; }
+
+        protected SpriteManager(String name, Vector2 coords, int width, int height)
+        {
+            // Initialise base sprite details. 
+            this.name = name;
+			SpriteDimensions = new Rectangle((int)coords.X, (int)coords.Y, width, height);
+        }
+
+        public void LoadContent(ContentManager content)
+        {
+            sprite = content.Load<Texture2D>(name);
+        }
+        
+
+		public virtual void Update(Rectangle windowDimensions, GameTime gt, ContentManager content)
+        {
+            // pass
+        }
+
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            spriteBatch.Begin();
+			spriteBatch.Draw(sprite, SpriteDimensions, Color.White);
+            spriteBatch.End();
+        }
+
+        public String Name { get; protected set; }
+    }
+}


### PR DESCRIPTION
Renamed SpashScreen -> VillageScreen.
Fixed problem changing screens in ScreenManager.
Converted all TileSize variables to the universal ScreenManager.Instance.TileSize.
Changed player speed to be independent of how fast the GPU is.
Added the MovementCommand for player movement.