### PR TITLE
NPC work + Background Tile compatibility fixes.

### DIFF
--- a/Source/Core/Grimthole.cs
+++ b/Source/Core/Grimthole.cs
@@ -53,7 +53,7 @@ namespace Grimthole.MacOS.Source
         {
             graphics.GraphicsDevice.Clear(Color.Black);
 
-            ScreenManager.Instance.Draw(spriteBatch);
+            ScreenManager.Instance.Draw(spriteBatch, gameTime);
 
             base.Draw(gameTime);
         }

--- a/Source/Core/Player.cs
+++ b/Source/Core/Player.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
-using Microsoft.Xna.Framework.Input;
 
 using Grimthole.MacOS.Source.Utils;
 using Grimthole.MacOS.Source.Interfaces;

--- a/Source/Core/Tile.cs
+++ b/Source/Core/Tile.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.Xna.Framework;
 
 namespace Grimthole.MacOS.Source.Core
 {

--- a/Source/NPCs/Villager.cs
+++ b/Source/NPCs/Villager.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Grimthole.MacOS.Source.Utils;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+
+namespace Grimthole.MacOS.Source.NPCs
+{
+    public class Villager : Entity
+    {
+        public string Response { get; }
+
+        public Villager(Vector2 coords) 
+            : base("Sprites/Man2front", coords, ScreenManager.Instance.TileSize, ScreenManager.Instance.TileSize)
+        {
+            Response = "It's a good day to live underground.";
+        }
+
+        public override void Update(Rectangle windowDimensions, GameTime gt, ContentManager content)
+        {
+            //throw new NotImplementedException();
+        }
+    }
+}

--- a/Source/Screens/Camera.cs
+++ b/Source/Screens/Camera.cs
@@ -1,13 +1,8 @@
-﻿using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Grimthole.Core;
+﻿using Grimthole.MacOS.Source.Core;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-namespace Grimthole.Screens
+namespace Grimthole.MacOS.Source.Screens
 {
     public class Camera
     {
@@ -27,13 +22,11 @@ namespace Grimthole.Screens
 
 
             var offset = Matrix.CreateTranslation(
-                GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width/2 -70, 
-                GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height/2 -70,
+                GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width / 2 - 70,
+                GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height / 2 - 70,
                 0);
             
             Transform = position * offset;
-
-
         }
     }
 }

--- a/Source/Screens/VillageScreen.cs
+++ b/Source/Screens/VillageScreen.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Grimthole.MacOS.Source.Controllers;
 using Grimthole.MacOS.Source.Core;
+using Grimthole.MacOS.Source.NPCs;
 using Grimthole.MacOS.Source.Utils;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -10,48 +11,54 @@ namespace Grimthole.MacOS.Source.Screens
     public class VillageScreen : GameScreen 
     {
         List<Vector2> points = new List<Vector2>();
+        List<Entity> npcs = new List<Entity>();
         Point tileHeightAndWidth;
         Player player;
         Texture2D SpriteSheet;
-        Tile Floor1;
-        Tile WallLt;
-        Tile WallRt;
-        Tile WallTp;
-        Tile WallBt;
-        Tile WallTL;
-        Tile WallTR;
-        Tile WallBL;
-        Tile WallBR;
-        Tile Stream;
+
         List<Tile> map = new List<Tile>();
         Camera camera;
 
         public override void LoadContent()
         {
             base.LoadContent();
-            SpriteSheet = Content.Load<Texture2D>("cave2");
-            Floor1 = new Tile(new Rectangle(new Point(0, 0), new Point(64, 64)));
-            Stream = new Tile(new Rectangle(new Point(64, 0), new Point(64, 64)));
-            WallBL = new Tile(new Rectangle(new Point(128, 0), new Point(64, 64)));
-            WallBR = new Tile(new Rectangle(new Point(192, 0), new Point(64, 64)));
-            WallLt = new Tile(new Rectangle(new Point(256, 0), new Point(64, 64)));
-            WallRt = new Tile(new Rectangle(new Point(320, 0), new Point(64, 64)));
-            WallTL = new Tile(new Rectangle(new Point(384, 0), new Point(64, 64)));
-            WallTR = new Tile(new Rectangle(new Point(448, 0), new Point(64, 64)));
-            WallTp = new Tile(new Rectangle(new Point(0, 64), new Point(64, 64)));
-            WallBt = new Tile(new Rectangle(new Point(576, 0), new Point(64, 64)));
-            controller = new ExplorationController();
 
             camera = new Camera();
 
-			//Draws the player in the middle of the region
-			player = new Player( new Vector2(
-				(ScreenManager.Instance.Dimensions.Width / 2 - ScreenManager.Instance.TileSize), 
-				(ScreenManager.Instance.Dimensions.Height / 2 - ScreenManager.Instance.TileSize)));
+            //Draws the player in the middle of the region
+            player = new Player(new Vector2(
+                (ScreenManager.Instance.Dimensions.Width / 2 - ScreenManager.Instance.TileSize),
+                (ScreenManager.Instance.Dimensions.Height / 2 - ScreenManager.Instance.TileSize)));
 
             player.LoadContent(Content);
 
-            //sets the region that is drawn
+            // Constructs All NPCs then iteratively loads their content.
+            Villager villager = new Villager(new Vector2(((player.pos.Left * 4) / 5), player.pos.Top));
+
+            npcs.Add(villager);
+
+            foreach (Entity npc in npcs)
+            {
+                npc.LoadContent(Content);
+            }
+
+            controller = new ExplorationController();
+
+            Tile Floor1 = new Tile(new Rectangle(new Point(0, 0), new Point(64, 64)));
+            Tile WallLt = new Tile(new Rectangle(new Point(64, 0), new Point(64, 64)));
+            Tile WallRt = new Tile(new Rectangle(new Point(128, 0), new Point(64, 64)));
+            Tile WallTp = new Tile(new Rectangle(new Point(192, 0), new Point(64, 64)));
+            Tile WallBt = new Tile(new Rectangle(new Point(256, 0), new Point(64, 64)));
+            Tile WallTL = new Tile(new Rectangle(new Point(320, 0), new Point(64, 64)));
+            Tile WallTR = new Tile(new Rectangle(new Point(384, 0), new Point(64, 64)));
+            Tile WallBL = new Tile(new Rectangle(new Point(448, 0), new Point(64, 64)));
+            Tile WallBR = new Tile(new Rectangle(new Point(0, 64), new Point(64, 64)));
+            Tile Stream = new Tile(new Rectangle(new Point(576, 0), new Point(64, 64)));
+
+            SpriteSheet = Content.Load<Texture2D>("Backgrounds/cave2");
+
+
+            // Sets the region that is drawn
             for (var i = 0; i < ScreenManager.Instance.TileSize * 40; i += ScreenManager.Instance.TileSize)
             {
                 for (var j = 0; j < ScreenManager.Instance.TileSize * 60; j += ScreenManager.Instance.TileSize)
@@ -117,6 +124,10 @@ namespace Grimthole.MacOS.Source.Screens
         {
 			controller.Update(player, gameTime);
             player.Update(ScreenManager.Instance.Dimensions, gameTime, Content);
+            foreach (Entity npc in npcs)
+            {
+                npc.Update(ScreenManager.Instance.Dimensions, gameTime, Content);
+            }
             camera.Follow(player, ScreenManager.Instance.Dimensions);
         }
 
@@ -132,6 +143,11 @@ namespace Grimthole.MacOS.Source.Screens
                 i++;
             }
             spriteBatch.End();
+
+            foreach (Entity npc in npcs)
+            {
+                npc.Draw(spriteBatch);
+            }
 
             player.Draw(spriteBatch);
         }

--- a/Source/Utils/Entity.cs
+++ b/Source/Utils/Entity.cs
@@ -2,9 +2,9 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Content;
-using Grimthole.Interfaces;
+using Grimthole.MacOS.Source.Interfaces;
 
-namespace Grimthole.Utils
+namespace Grimthole.MacOS.Source.Utils
 {
 	/// <summary>
     /// An Entity is any Sprite that is 'alive.'

--- a/Source/Utils/GameScreen.cs
+++ b/Source/Utils/GameScreen.cs
@@ -28,6 +28,6 @@ namespace Grimthole.MacOS.Source.Utils
 
         public abstract void Update(GameTime gameTime);
 
-        public abstract void Draw(SpriteBatch spriteBatch);
+        public abstract void Draw(SpriteBatch spriteBatch, GameTime gameTime);
     }
 }


### PR DESCRIPTION
The Majority of the work was namespacing and the new background tiling-camera work compatibility fixes. The rest of it involved adding the Villager npc, as well as adding an List<Entity> npcs in the Village screen that stores all the npcs and automatically calls their update and draw methods.

**Changed Classes:**
> Core/Grimthole.cs
> Core/Tile.cs
> Core/Player.cs
> 
> Utils/Entity.cs
> Utils/GameScreen.cs
> 
> NPCs/Villager.cs
> 
> Screens/Camera.cs
> Screens/VillageScreen.cs